### PR TITLE
Fix crash when calling zlib.deflate()()

### DIFF
--- a/lua_zlib.c
+++ b/lua_zlib.c
@@ -95,7 +95,6 @@ static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end
      int flush = Z_NO_FLUSH, result;
      z_stream* stream;
      luaL_Buffer buff;
-     size_t avail_in;
 
     if ( filter == deflate ) {
         const char *const opts[] = { "none", "sync", "full", "finish", NULL };
@@ -132,8 +131,16 @@ static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end
     }
 
     /*  Do the actual deflate'ing: */
-    stream->next_in = (unsigned char*)lua_tolstring(L, -1, &avail_in);
-    stream->avail_in = avail_in;
+    if (lua_gettop(L) > 0 && lua_isstring(L, -1))
+    {
+      stream->next_in = (unsigned char*)lua_tolstring(L, -1, &stream->avail_in);
+    }
+    else
+    {
+      stream->next_in = 0;
+      stream->avail_in = 0;
+    }
+
     if ( ! stream->avail_in && ! flush ) {
         /*  Passed empty string, make it a noop instead of erroring out. */
         lua_pushstring(L, "");


### PR DESCRIPTION
It looks like zlib.deflate()() is intended to be equivalent to zlib.deflate()("", "finish"), but lua_tolstring was potentially accessing an invalid stack element, which could cause crashes. This fixes it by checking to ensure the stack element is valid before the access.
