### PR TITLE
remove unneded linking against lua library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
     lua_zlib.c zlib.def)
   SET_TARGET_PROPERTIES(cmod_zlib PROPERTIES PREFIX "")
   SET_TARGET_PROPERTIES(cmod_zlib PROPERTIES OUTPUT_NAME zlib)
-  TARGET_LINK_LIBRARIES(cmod_zlib ${LUA_LIBRARIES} ${ZLIB_LIBRARIES})
+  TARGET_LINK_LIBRARIES(cmod_zlib ${ZLIB_LIBRARIES})
 # / build zlib.so
 
 # Define how to test zlib.so:


### PR DESCRIPTION
Only 3rd-party apps need to be linked against lua library, but not a lua modules.

Signed-off-by: Vadim A. Misbakh-Soloviov mva@mva.name
