### PR TITLE
Fixes build for windows and syntax errors in rockspec.

### DIFF
--- a/lua-zlib-0.5-0.rockspec
+++ b/lua-zlib-0.5-0.rockspec
@@ -8,7 +8,7 @@ description = {
    summary = "Simple streaming interface to zlib for Lua.",
    detailed = [[
       Simple streaming interface to zlib for Lua.
-      Consists of two functions: inflate and deflate. 
+      Consists of two functions: inflate and deflate.
       Both functions return "stream functions" (takes a buffer of input and returns a buffer of output).
       This project is hosted on github.
    ]],
@@ -28,9 +28,13 @@ build = {
    type = "builtin",
    modules = {
       zlib = {
-         sources = { "lua_zlib.c" };
+         sources = { "lua_zlib.c" },
          libraries = { "z" },
          defines = { "LZLIB_COMPAT" },
-      };
+         incdirs = { "$(ZLIB_INCDIR)" },
+      }
+   },
+   platforms = {
+      windows = { modules = { zlib = { libraries = { "$(ZLIB_LIBDIR)/zlib" } } } }
    }
 }

--- a/lua-zlib-0.5-0.rockspec
+++ b/lua-zlib-0.5-0.rockspec
@@ -35,6 +35,8 @@ build = {
       }
    },
    platforms = {
-      windows = { modules = { zlib = { libraries = { "$(ZLIB_LIBDIR)/zlib" } } } }
+      windows = { modules = { zlib = { libraries = {
+         "$(ZLIB_LIBDIR)/zlib" -- Must full path to `"zlib"`, or else will cause the `LINK : fatal error LNK1149`
+      } } } }
    }
 }


### PR DESCRIPTION
Fixes for rockspec files.

1. Fixes build under windows where zlib has link library named `zlib` rahter than `z`.
2. Some nested table ends with `;` should be changed to `,`.

BTW: the 1.0 release is not on any branch.

Look forward for next release, we need it on windows.