### PR TITLE
Windows must use zlibstatic.

### DIFF
--- a/lua-zlib-1.1-0.rockspec
+++ b/lua-zlib-1.1-0.rockspec
@@ -36,7 +36,8 @@ build = {
    },
    platforms = {
       windows = { modules = { zlib = { libraries = {
-         "$(ZLIB_LIBDIR)/zlib" -- Must full path to `"zlib"`, or else will cause the `LINK : fatal error LNK1149`
+         "$(ZLIB_LIBDIR)/zlibstatic" -- Must full path to `"zlibstatic"`, or else will cause the `LINK : fatal error LNK1149`.
+            -- And must use zlibstatic because this rock crates a dll named zlib.dll
       } } } }
    }
 }


### PR DESCRIPTION
The zlib C library will have dll library named `zlib.dll`.
This rock will create a dll named `zlib.dll`.

With the same name, in runtime, the system will try to find zlib C library's functions in this rock's `zlib.dll` which will fail.