### PR TITLE
Use lua_Integer instead of lua_Number for checksum calculation

### DIFF
--- a/lua_zlib.c
+++ b/lua_zlib.c
@@ -1148,21 +1148,21 @@ static int lz_checksum(lua_State *L) {
 
         lua_pushvalue(L, 1);
         lua_call(L, 0, 2);
-        if ( ! lua_isnumber(L, -2) || ! lua_isnumber(L, -1) ) {
+        if ( ! lua_isinteger(L, -2) || ! lua_isinteger(L, -1) ) {
             luaL_argerror(L, 1, "expected function to return two numbers");
         }
 
         /* Calculate and replace the checksum */
-        lua_pushnumber(L,
-                       combine((uLong)lua_tonumber(L, lua_upvalueindex(3)),
-                               (uLong)lua_tonumber(L, -2),
-                               (z_off_t)lua_tonumber(L, -1)));
+        lua_pushinteger(L,
+                       combine((uLong)lua_tointeger(L, lua_upvalueindex(3)),
+                               (uLong)lua_tointeger(L, -2),
+                               (z_off_t)lua_tointeger(L, -1)));
         lua_pushvalue(L, -1);
         lua_replace(L, lua_upvalueindex(3));
 
         /* Calculate and replace the length */
-        lua_pushnumber(L,
-                       lua_tonumber(L, lua_upvalueindex(4)) + lua_tonumber(L, -2));
+        lua_pushinteger(L,
+                       lua_tointeger(L, lua_upvalueindex(4)) + lua_tointeger(L, -2));
         lua_pushvalue(L, -1);
         lua_replace(L, lua_upvalueindex(4));
     } else {
@@ -1174,16 +1174,16 @@ static int lz_checksum(lua_State *L) {
         str = (const Bytef*)luaL_checklstring(L, 1, &len);
  
         /* Calculate and replace the checksum */
-        lua_pushnumber(L,
-                       checksum((uLong)lua_tonumber(L, lua_upvalueindex(3)),
+        lua_pushinteger(L,
+                       checksum((uLong)lua_tointeger(L, lua_upvalueindex(3)),
                                 str,
                                 len));
         lua_pushvalue(L, -1);
         lua_replace(L, lua_upvalueindex(3));
         
         /* Calculate and replace the length */
-        lua_pushnumber(L,
-                       lua_tonumber(L, lua_upvalueindex(4)) + len);
+        lua_pushinteger(L,
+                       lua_tointeger(L, lua_upvalueindex(4)) + len);
         lua_pushvalue(L, -1);
         lua_replace(L, lua_upvalueindex(4));
     }
@@ -1193,8 +1193,8 @@ static int lz_checksum(lua_State *L) {
 static int lz_checksum_new(lua_State *L, checksum_t checksum, checksum_combine_t combine) {
     lua_pushlightuserdata(L, checksum);
     lua_pushlightuserdata(L, combine);
-    lua_pushnumber(L, checksum(0L, Z_NULL, 0));
-    lua_pushnumber(L, 0);
+    lua_pushinteger(L, checksum(0L, Z_NULL, 0));
+    lua_pushinteger(L, 0);
     lua_pushcclosure(L, lz_checksum, 4);
     return 1;
 }

--- a/test.lua
+++ b/test.lua
@@ -174,6 +174,9 @@ function test_illegal_state()
 end
 
 function test_checksum()
+   ok(lz.crc32()("123456789") == 0xCBF43926, "crc32()(\"123456789\") == 0xCBF43926")
+   ok(lz.adler32()("123456789") == 0x091E01DE, "adler()(\"123456789\") == 0x091E01DE")
+
    for _, factory in pairs{lz.crc32, lz.adler32} do
       local csum = factory()("one two")
 


### PR DESCRIPTION
We are using Lua on an embedded system with 32 bit. Accordingly, lua_Numbers are 32 bit floats not able to store 32 bit integer-checksums. I've replaced all calls like lua_pushnumber(), lua_tonumber() etc. with their integer counterparts like lua_pushinteger(), lua_tointeger etc. Besides I've added two checks in test.lua to show the correct results.

We use Lua 5.3 and 5.4 only. I didn't check for compatibility issues with older Lua versions that might not support integers correctly. If you merge this PR you may have to add conditions like #if (LUA_VERSION_NUM >= 503) to maintain compatibility with older versions.