### PR TITLE
fix unauthenticated git protocol on port 9418

### DIFF
--- a/rockspecs/lua-zlib-1.2-2.rockspec
+++ b/rockspecs/lua-zlib-1.2-2.rockspec
@@ -1,0 +1,42 @@
+package = "lua-zlib"
+version = "1.2-2"
+source = {
+   url = "git@github.com/brimworks/lua-zlib.git",
+   tag = "v1.2",
+}
+description = {
+   summary = "Simple streaming interface to zlib for Lua.",
+   detailed = [[
+      Simple streaming interface to zlib for Lua.
+      Consists of two functions: inflate and deflate.
+      Both functions return "stream functions" (takes a buffer of input and returns a buffer of output).
+      This project is hosted on github.
+   ]],
+   homepage = "https://github.com/brimworks/lua-zlib",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1, <= 5.4"
+}
+external_dependencies = {
+    ZLIB = {
+       header = "zlib.h"
+    }
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      zlib = {
+         sources = { "lua_zlib.c" },
+         libraries = { "z" },
+         defines = { "LZLIB_COMPAT" },
+         incdirs = { "$(ZLIB_INCDIR)" },
+      }
+   },
+   platforms = {
+      windows = { modules = { zlib = { libraries = {
+         "$(ZLIB_LIBDIR)/zlib" -- Must full path to `"zlib"`, or else will cause the `LINK : fatal error LNK1149`
+      } } } }
+   }
+}

--- a/rockspecs/lua-zlib-1.2-2.rockspec
+++ b/rockspecs/lua-zlib-1.2-2.rockspec
@@ -1,7 +1,7 @@
 package = "lua-zlib"
 version = "1.2-2"
 source = {
-   url = "git@github.com/brimworks/lua-zlib.git",
+   url = "git+https://github.com/brimworks/lua-zlib.git",
    tag = "v1.2",
 }
 description = {


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Fix in the PR