### PR TITLE
avoid converting string to char *.

### DIFF
--- a/lua_zlib.c
+++ b/lua_zlib.c
@@ -924,7 +924,7 @@ static int lz_assert(lua_State *L, int result, const z_stream* stream, const cha
  *
  * if no params, terminates the stream (as if we got empty string and Z_FINISH).
  */
-static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end)(z_streamp), char* name) {
+static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end)(z_streamp), const char* name) {
     int flush = Z_NO_FLUSH, result;
     z_stream* stream;
     luaL_Buffer buff;


### PR DESCRIPTION
The `name` parameters of `lz_filter_impl` function may convert C string to char *, this commit add `const` qualifier.