### PR TITLE
Explicitly cast integers to pointers when pushing checksum on Lua stack

### DIFF
--- a/lua_zlib.c
+++ b/lua_zlib.c
@@ -1191,8 +1191,8 @@ static int lz_checksum(lua_State *L) {
 }
 
 static int lz_checksum_new(lua_State *L, checksum_t checksum, checksum_combine_t combine) {
-    lua_pushlightuserdata(L, checksum);
-    lua_pushlightuserdata(L, combine);
+    lua_pushlightuserdata(L, (void *)checksum);
+    lua_pushlightuserdata(L, (void *)combine);
     lua_pushnumber(L, checksum(0L, Z_NULL, 0));
     lua_pushnumber(L, 0);
     lua_pushcclosure(L, lz_checksum, 4);


### PR DESCRIPTION
This does not cause any change in functionality.  It just explicitly casts integers as necessary to allow lua-zlib to build cleanly as C++.  This is beneficial for projects that build Lua as C++ (e.g. to simplify raising Lua errors when implementing Lua bindings for C++ objects).