### PR TITLE
CI: use up-to-date GitHub Actions to install Lua and LuaRocks

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v9
+      uses: luarocks/gh-actions-lua@v10
       with:
         luaVersion: ${{ matrix.luaVersion }}
     - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
+      uses: luarocks/gh-actions-luarocks@v5
     - name: Build & install
       run: |
         luarocks --local make


### PR DESCRIPTION
## Description

At the moment, it's well known by the Lua community that the current GitHub Action ([https://github.com/leafo/gh-actions-lua](https://github.com/leafo/gh-actions-lua)) configured on this project is unable to install LuaJIT (see [https://github.com/leafo/gh-actions-lua/issues/49](https://github.com/leafo/gh-actions-lua/issues/49)), because tarballs were removed from LuaJIT website, causing the action to fail.

Nowadays, it's a common practice for Lua projects hosted on GitHub to employ the (forked and) up-to-date actions [https://github.com/luarocks/gh-actions-lua](https://github.com/luarocks/gh-actions-lua) to install Lua and [https://github.com/luarocks/gh-actions-luarocks](https://github.com/luarocks/gh-actions-luarocks) to install LuaRocks.

I think that @alerque could be interested on this, because he contributed on this repository recently, and he is often involved with such actions.

> [!NOTE]
> 
> I've found a few issues on this library, and I have prepared fixes for them. However, the current CI is failing on such LuaJIT installation issues, which could be resolved first by merging this PR.