### PR TITLE
fix: tests for zlib 1.3

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -180,7 +180,11 @@ local function test_version()
    local major, minor, patch = lz.version()
    ok(1 == major, "major version 1 == " .. major);
    ok(type(minor) == "number", "minor version is number (" .. minor .. ")")
-   ok(type(patch) == "number", "patch version is number (" .. patch .. ")")
+   if ( patch == nil ) then
+      ok(patch == nil, "patch version is empty or is number (empty)")
+   else
+      ok(type(patch) == "number", "patch version is empty or is number (" .. patch .. ")")
+   end
 end
 
 local function main()


### PR DESCRIPTION
## Description

Fixes [https://github.com/brimworks/lua-zlib/issues/70](https://github.com/brimworks/lua-zlib/issues/70)

## Changes

The described issue was already reported on Debian's bug tracker (see [https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058504](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058504)). In order to fix this issue, Debian developers applied this patch [https://salsa.debian.org/lua-team/lua-zlib/-/blob/f7bc945ce29c35854b6abd72d8938054e578bbcc/debian/patches/test-patchlevel.diff](https://salsa.debian.org/lua-team/lua-zlib/-/blob/f7bc945ce29c35854b6abd72d8938054e578bbcc/debian/patches/test-patchlevel.diff). So, I just used this patch here.