### PR TITLE
fixes development rockspec for MinGW and adds Windows / macOS to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,65 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ "ubuntu-20.04", "macos-14", "windows-2025" ]
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    env:
+      LUAROCKS_WINDOWS_DEPS_DIR: C:\external
+      WINDOWS_ZLIB_VERSION: 1.3.1
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Setup MSVC command prompt
+      if: ${{ runner.os == 'Windows' && !startsWith(matrix.luaVersion, 'luajit') }}
+      uses: ilammy/msvc-dev-cmd@v1
     - name: Setup ‘lua’
       uses: luarocks/gh-actions-lua@v10
       with:
         luaVersion: ${{ matrix.luaVersion }}
     - name: Setup ‘luarocks’
       uses: luarocks/gh-actions-luarocks@v5
+    - name: Restore zlib tarball on Windows
+      if: ${{ runner.os == 'Windows' }}
+      id: restore-zlib-tarball
+      uses: actions/cache/restore@v4
+      with:
+        path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
+        key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"
+    - name: Download zlib
+      if: ${{ runner.os == 'Windows' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
+      run: curl -L -O "https://zlib.net/fossils/zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
+    - name: Save zlib tarball
+      if: ${{ runner.os == 'Windows' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
+        key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"
+    - name: Extract, configure, build and install zlib on Windows
+      shell: cmd
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        tar -xf "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
+        IF "${{ matrix.luaVersion }}"=="luajit" (
+          SET CMAKE_GENERATOR=MinGW Makefiles
+        ) ELSE IF "${{ matrix.luaVersion }}"=="luajit-openresty" (
+          SET CMAKE_GENERATOR=MinGW Makefiles
+        ) ELSE (
+          SET CMAKE_GENERATOR=NMake Makefiles
+        )
+        cmake ^
+          -G "%CMAKE_GENERATOR%" ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DBUILD_SHARED_LIBS=ON ^
+          --install-prefix "${{ env.LUAROCKS_WINDOWS_DEPS_DIR }}" ^
+          -S "zlib-${{ env.WINDOWS_ZLIB_VERSION }}" ^
+          -B build-zlib && ^
+        cmake --build build-zlib --config Release && ^
+        cmake --install build-zlib --config Release
+        echo ${{ env.LUAROCKS_WINDOWS_DEPS_DIR }}\bin>>${{ github.path }}
+    - name: Lint rockspec
+      run: luarocks lint lua-zlib-scm-0.rockspec
     - name: Build & install
-      run: |
-        luarocks --local make
+      run: luarocks make lua-zlib-scm-0.rockspec
     - name: Run tests
-      run: |
-        lua test.lua
+      run: lua test.lua

--- a/lua-zlib-scm-0.rockspec
+++ b/lua-zlib-scm-0.rockspec
@@ -32,11 +32,24 @@ build = {
          libraries = { "z" },
          defines = { "LZLIB_COMPAT" },
          incdirs = { "$(ZLIB_INCDIR)" },
+         libdirs = { "$(ZLIB_LIBDIR)" }
       }
    },
    platforms = {
-      windows = { modules = { zlib = { libraries = {
-         "$(ZLIB_LIBDIR)/zlib" -- Must full path to `"zlib"`, or else will cause the `LINK : fatal error LNK1149`
-      } } } }
+      windows = {
+         modules = {
+            zlib = {
+               libraries = { "zlib" }
+            }
+         }
+      },
+      mingw = {
+         modules = {
+            zlib = {
+               libraries = { "zlib1" },
+               libdirs = { "$(ZLIB_INCDIR)/../bin" }
+            }
+         }
+      }
    }
 }


### PR DESCRIPTION
## Description

This PR has two purposes:

1. fixes the development rockspec (```lua-zlib-scm-0.rockspec```) for MinGW / MinGW-w64 on Windows, and simplifies the build on Unix or MSVC on Windows;
2. adds ```macos-14``` and ```windows-2025``` to the test matrix.

## Changes on ```lua-zlib-scm-0.rockspec```

1. The entry ```libdirs = { "$(ZLIB_LIBDIR)" }``` was added to the default build rule. This change allows to build ```lua-zlib``` with zlib installed at custom places on both Unix and Windows through the command
  ```bash
  luarocks make lua-zlib-scm-0.rockspec ZLIB_DIR=/path/to/zlib
  ```
> [!NOTE]
> 
> The old setting only linked with zlib from system directories (```/usr/lib``` and ```/usr/local/lib```).

2. The platform-override entry for ```mingw``` solves the linking problem for both MinGW / MinGW-w64 on Windows. Here, I applied a clever trick: on Windows, MinGW / MinGW-w64 can link libraries by the feeding the DLL to the linker. Then, grounded on the fact that a standard zlib installation always emits a DLL named ```libzlib1.dll``` or ```zlib1.dll```, the build rules of LuaRocks allows it to link ```lua-zlib``` with zlib via the DLL.

## Changes on ```.github/workflows/test.yml```

1. added ```macos-14``` and ```windows-2025``` to the test matrix;
2. building zlib 1.3.1 from source code on Windows;
3. caching zlib tarballs to avoid flooding (DOS) zlib website [https://zlib.net](https://zlib.net);
4. builds of (PUC-Rio) Lua 5.4, 5.3, 5.2 and 5.1 uses MSVC toolchain on Windows;
5. builds of LuaJIT and OpenResty uses the standard MinGW-w64 toolchain provided by GitHub on Windows.

## Notes

1. If any user complains about not being able to build ```lua-zlib``` with MinGW / MinGW-w64 through ```lua-zlib-scm-0.rockspec```, most likely it is related to a misconfiguration of LuaRocks. Also, anytime it happens, feel free to mention me through a @ , because I think I can help;
2. Even though it is not present in the workflow, I tested the changed rockspec with multiple MinGW / MinGW-w64 providers (GitHub provider, MSYS2 provider, sourceforge provider), and they are all working fine;
3. In my opinion, it might be a good time to push a new rockspec to [https://luarocks.org/](https://luarocks.org/) based on ```lua-zlib-scm-0.rockspec```.