### PR TITLE
fix(README.md): 1- zlib URL; 2 - patch version type description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides a functional, streaming interface to zlib.
 ## Prerequisites
 
 To use this library, you need zlib, get it here:
-* <http://www.gzip.org/zlib/>
+* [https://zlib.net/](https://zlib.net/)
 
 ## Installing
 
@@ -35,7 +35,7 @@ luaopen_zlib(L);
 ```lua
 -- @return major (integer)
 -- @return minor (integer)
--- @return patch (integer)
+-- @return patch (integer | nil)
 local major, minor, patch = zlib.version()
 ```
 


### PR DESCRIPTION
## Description

1. Fixes zlib URL (the current one is returning a 404 error - NOT FOUND)
2. Changes the description about the returned type of `patch` in `zlib.version()` method: the correct return type is `integer` or `nil`, because for zlib 1.3, the returned `patch` is `nil` (see [https://github.com/brimworks/lua-zlib/issues/70](https://github.com/brimworks/lua-zlib/issues/70), which was fixed by [https://github.com/brimworks/lua-zlib/pull/71](https://github.com/brimworks/lua-zlib/pull/71))