### PR TITLE
fix(ci): ubuntu-20.04 image is being phased out

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
 
   luacheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-20.04", "macos-14", "windows-2025" ]
+        os: [ "ubuntu-24.04", "macos-14", "windows-2025" ]
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
## Description

Currently, the Ubuntu image configured on CI (`ubuntu-20.04`) is being phased out (see [https://github.com/actions/runner-images/issues/11101](https://github.com/actions/runner-images/issues/11101)) and does not run anymore.

## Changes

Replaced `ubuntu-20.04` by `ubuntu-24.04`

## Screenshots

During the update of my fork to the current state, CI didn't run on Ubuntu due image retirement:

![image](https://github.com/user-attachments/assets/419d4594-0c36-4d09-a5ce-2d7827e5b4a1)
