### PR TITLE
support Lua 5.5

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,5 +1,5 @@
 Author  : Brian Maher <brian at brimworks dot com>
-Library : lua_zlib - Lua 5.1 to Lua 5.4 interface to zlib
+Library : lua_zlib - Lua 5.1 to Lua 5.5 interface to zlib
 
 The MIT License
 

--- a/lua-zlib-scm-0.rockspec
+++ b/lua-zlib-scm-0.rockspec
@@ -16,7 +16,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, <= 5.4"
+   "lua >= 5.1, <= 5.5"
 }
 external_dependencies = {
     ZLIB = {


### PR DESCRIPTION
## Description

This PR adds Lua 5.5 support

## Notes

At the moment, there's **NOT** a released LuaRocks version that officially supports Lua 5.5. However, Lua 5.5 support on LuaRocks is progressing (see [https://github.com/luarocks/luarocks/pull/1844](https://github.com/luarocks/luarocks/pull/1844)) and it is already able to build local modules.

Moreover, the current CI on this project is unable to properly test `lua-zlib` on Lua 5.5, because the involved actions depends on official released LuaRocks versions.

For this reason, I implemented the whole CI to test this PR branch on Ubuntu + macOS + Windows (both MSVC + MinGW-w64 on Windows) using [https://github.com/luarocks/hererocks](https://github.com/luarocks/hererocks) to install Lua 5.5 + LuaRocks from the commit `6b7b6c2506f9abef059794663a8598a736837cc4`.

You can browse how CI ran on my PR branch, including Lua 5.1 - 5.5, here: [https://github.com/luau-project/ci-tests/actions/runs/20524106344](https://github.com/luau-project/ci-tests/actions/runs/20524106344)

<details>
<summary>Click to hide/unhide the workflow employed in the tests</summary>

```yaml
name: Test

on: push

jobs:
  test:
    runs-on: ${{ matrix.os }}
    strategy:
      fail-fast: false
      matrix:
        os:
          - ubuntu-latest
          - macos-latest
          - windows-latest
        lua-version:
          - 5.1
          - 5.2
          - 5.3
          - 5.4
          - 5.5
        is-msvc:
          - false
          - true

        exclude:
          - os: ubuntu-latest
            is-msvc: true

          - os: macos-latest
            is-msvc: true
    env:
      HEREROCKS_URL: git+https://github.com/luarocks/hererocks
      LUAROCKS_COMMIT: 6b7b6c2506f9abef059794663a8598a736837cc4

      LUAROCKS_WINDOWS_DEPS_DIR: C:\external
      WINDOWS_ZLIB_VERSION: 1.3.1

    steps:
      - name: Checkout lua-zlib from PR branch
        uses: actions/checkout@v6
        with:
          repository: luau-project/lua-zlib
          ref: lua-5.5

      - name: Install readline
        if: ${{ runner.os == 'Linux' }}
        run: sudo apt install -y libreadline-dev

      - name: Setup MSVC dev prompt
        if: ${{ runner.os == 'Windows' && matrix.is-msvc }}
        uses: ilammy/msvc-dev-cmd@v1

      - name: Restore zlib tarball on Windows
        if: ${{ runner.os == 'Windows' }}
        id: restore-zlib-tarball
        uses: actions/cache/restore@v5
        with:
          path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
          key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"

      - name: Download zlib (Windows)
        if: ${{ runner.os == 'Windows' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
        run: curl -L -O "https://zlib.net/fossils/zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"

      - name: Save zlib tarball (Windows)
        if: ${{ runner.os == 'Windows' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
        uses: actions/cache/save@v5
        with:
          path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
          key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"

      - name: Extract, configure, build and install zlib (Windows)
        shell: cmd
        if: ${{ runner.os == 'Windows' }}
        run: |
          tar -xf "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"

          IF %ERRORLEVEL% NEQ 0 (
            ECHO Failed to extract zlib tarball
            EXIT /B 1
          )

          IF "${{ matrix.is-msvc }}"=="true" (
            SET CMAKE_GENERATOR=NMake Makefiles
            ECHO HEREROCKS_TARGET=vs>>${{ github.env }}
          ) ELSE (
            SET CMAKE_GENERATOR=MinGW Makefiles
            ECHO HEREROCKS_TARGET=mingw>>${{ github.env }}
          )

          cmake ^
            -G "%CMAKE_GENERATOR%" ^
            -DCMAKE_BUILD_TYPE=Release ^
            -DBUILD_SHARED_LIBS=ON ^
            --install-prefix "${{ env.LUAROCKS_WINDOWS_DEPS_DIR }}" ^
            -S "zlib-${{ env.WINDOWS_ZLIB_VERSION }}" ^
            -B build-zlib && ^
          cmake --build build-zlib --config Release && ^
          cmake --install build-zlib --config Release

          IF %ERRORLEVEL% EQU 0 (
            ECHO ${{ env.LUAROCKS_WINDOWS_DEPS_DIR }}\bin>>${{ github.path }}
          ) ELSE (
            ECHO Failed to configure, build or install zlib
            EXIT /B 1
          )

      - name: Set up Python 3.13
        uses: actions/setup-python@v5
        with:
          python-version: "3.13"

      - name: Install hererocks
        run: pip install ${{ env.HEREROCKS_URL }}

      - name: Install Lua and LuaRocks (Unix)
        if: ${{ runner.os != 'Windows' }}
        run: hererocks ".lua" "-l${{ matrix.lua-version }}" "-r@${{ env.LUAROCKS_COMMIT }}"

      - name: Install Lua and LuaRocks (Windows)
        if: ${{ runner.os == 'Windows' }}
        run: hererocks ".lua" "-l${{ matrix.lua-version }}" "-r@${{ env.LUAROCKS_COMMIT }}" "--target=${{ env.HEREROCKS_TARGET }}"

      - name: Place Lua and LuaRocks on system PATH environment variable
        shell: pwsh
        run: |
          if ("${{ runner.os }}" -eq "Windows")
          {
            $ext = ".exe";
          }
          else
          {
            $ext = "";
          }
          Get-ChildItem ".lua" -Recurse -File |
          Where-Object Name -EQ "lua${ext}" |
          Select-Object -ExpandProperty FullName -First 1 |
          Split-Path |
          ForEach-Object {
            Write-Host "Adding directory `"$_`" to system PATH environment variable (GitHub-only)";
            Add-Content "${{ github.path }}" "$_";
          }

      - name: Set LUA_CPATH environment variable on GitHub
        shell: pwsh
        run: |
          $value = & luarocks path --lr-cpath;
          Add-Content "${{ github.env }}" "LUA_CPATH=${value}";

      - name: Set LUA_PATH environment variable on GitHub
        shell: pwsh
        run: |
          $value = & luarocks path --lr-path;
          Add-Content "${{ github.env }}" "LUA_PATH=${value}";

      - name: Set PATH environment variable on GitHub
        shell: pwsh
        run: |
          $value = & luarocks path --lr-bin;
          $delimiter = [System.IO.Path]::PathSeparator;
          Add-Content "${{ github.env }}" "PATH=${value}${delimiter}${env:PATH}";

      - name: Lint rockspec
        run: luarocks lint lua-zlib-scm-0.rockspec

      - name: Build and install
        run: luarocks make lua-zlib-scm-0.rockspec

      - name: Run tests
        run: lua test.lua
```

</details>