### PR TITLE
ci: use up-to-date actions to work with Lua 5.5 and LuaRocks 3.13.0

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Luacheck
         uses: lunarmodules/luacheck@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,28 +8,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-24.04", "macos-14", "windows-2025" ]
-        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
+        os: [ "ubuntu-24.04", "macos-15", "windows-2025" ]
+        luaVersion: [ "5.5", "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
     runs-on: ${{ matrix.os }}
     env:
       LUAROCKS_WINDOWS_DEPS_DIR: C:\external
       WINDOWS_ZLIB_VERSION: 1.3.1
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSVC command prompt
       if: ${{ runner.os == 'Windows' && !startsWith(matrix.luaVersion, 'luajit') }}
       uses: ilammy/msvc-dev-cmd@v1
     - name: Setup ‘lua’
-      uses: luarocks/gh-actions-lua@v10
+      uses: luarocks/gh-actions-lua@816ec4c55af2f6dcb9dfcba372d93dd1fb5fa8f2
       with:
         luaVersion: ${{ matrix.luaVersion }}
     - name: Setup ‘luarocks’
-      uses: luarocks/gh-actions-luarocks@v5
+      uses: luarocks/gh-actions-luarocks@e42874645a111d78a858c3dba7530bdd707b21a4
     - name: Restore zlib tarball on Windows
       if: ${{ runner.os == 'Windows' }}
       id: restore-zlib-tarball
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
         key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"
@@ -38,7 +38,7 @@ jobs:
       run: curl -L -O "https://zlib.net/fossils/zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
     - name: Save zlib tarball
       if: ${{ runner.os == 'Windows' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}.tar.gz"
         key: "zlib-${{ env.WINDOWS_ZLIB_VERSION }}"


### PR DESCRIPTION
## Description

* **Main change**: added Lua 5.5 to the matrix of tests
* **Secondary changes**: updated the version of actions.
    * The version of luarocks/gh-actions-lua and luarockt/gh-actions-luarocks were pinned by the commit (`sha`) in the master branch that introduced Lua 5.5 and LuaRocks 3.13.0, respectively.

> [!TIP]
> 
> Once you get free time, please, upload a new version of the rockspec on LuaRocks website to allow Lua 5.5 adopters to use `lua-zlib`.

Have a happy new year!
